### PR TITLE
Fix Slowbro Dive

### DIFF
--- a/data/maps/MossdeepCity/scripts.inc
+++ b/data/maps/MossdeepCity/scripts.inc
@@ -403,7 +403,7 @@ MossdeepCity_Text_ItsAWhiteRock: @ 81E5396
 
 MossdeepCity_Text_GymSign: @ 81E53A9
 	.string "Mossdeep City Pokémon Gym\n"
-	.string "Leaders: Liza & Tate\p"
+	.string "Leaders: Tate & Liza\p"
 	.string "“The mystic combination!”$"
 
 MossdeepCity_Text_CitySign: @ 81E53F2

--- a/data/maps/MossdeepCity_Gym/scripts.inc
+++ b/data/maps/MossdeepCity_Gym/scripts.inc
@@ -608,7 +608,7 @@ MossdeepCity_Gym_Text_ExplainCalmMind: @ 8221A40
 	.string "… … … … … …$"
 
 MossdeepCity_Gym_Text_RegisteredTateAndLiza: @ 8221AEA
-	.string "Registered Gym Leaders Liza & Tate\n"
+	.string "Registered Gym Leaders Tate & Liza\n"
 	.string "in the PokéNav.$"
 
 MossdeepCity_Gym_Text_TateAndLizaPostBattle: @ 8221B1D

--- a/data/scripts/field_move_scripts.inc
+++ b/data/scripts/field_move_scripts.inc
@@ -514,9 +514,10 @@ Text_MonUsedWaterfall: @ 8290AFC
 
 EventScript_UseDive:: @ 8290B0F
 	lockall
+	goto_if_unset FLAG_BADGE07_GET, EventScript_CantDive
 	checkpartymove MOVE_DIVE
 	compare VAR_RESULT, PARTY_SIZE
-	goto_if_eq EventScript_CantDive
+	goto_if_eq EventScript_SlowbroDive
 	bufferpartymonnick 0, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
 	setfieldeffectargument 1, 1
@@ -534,8 +535,6 @@ EventScript_SlowbroDive::
 	setvar VAR_0x8009, 1
 	bufferspeciesname 0, VAR_0x8004	
 	buffermovename 1, VAR_0x8008
-	setfieldeffectargument 0, VAR_RESULT
-	setfieldeffectargument 1, 1
 	msgbox Text_SlowbroDive, MSGBOX_YESNO
 	compare VAR_RESULT, NO
 	goto_if_eq EventScript_EndDive
@@ -575,9 +574,6 @@ EventScript_SlowbroSurface::
 	setvar VAR_0x8009, 1
 	bufferspeciesname 0, VAR_0x8004
 	buffermovename 1, VAR_0x8008
-	bufferpartymonnick 0, VAR_RESULT
-	setfieldeffectargument 0, VAR_RESULT
-	setfieldeffectargument 1, 1
 	msgbox Text_WantToSurface, MSGBOX_YESNO
 	compare VAR_RESULT, NO
 	goto_if_eq EventScript_EndSurface
@@ -600,7 +596,7 @@ Text_WantToDive: @ 8290BE8
 
 Text_SlowbroDive:
 	.string "The sea is deep here.\n"
-	.string "Call Liza & Tate's Slowbro to Dive?$"
+	.string "Call Tate & Liza's Slowbro to Dive?$"
 
 Text_MonUsedDive: @ 8290C1A
 	.string "{STR_VAR_1} used Dive.$"

--- a/src/strings.c
+++ b/src/strings.c
@@ -1979,7 +1979,7 @@ const u8 gText_ElectricTerrain[] = _("ElectroField");
 const u8 gText_MistyTerrain[] = _("Misty Field");
 const u8 gText_PsychicTerrain[] = _("PsychicField");
 
-// Unlocked after beating Liza & Tate
+// Unlocked after beating Tate & Liza
 const u8 gText_DoubleEdge[] = _("Double-Edge");
 const u8 gText_PlayRough[] = _("Play Rough");
 const u8 gText_NastyPlot[] = _("Nasty Plot");


### PR DESCRIPTION
Player can now use Tate and Liza's Slowbro to Dive instead of their own mon. Also reverted ORAS name swap for Tate & Liza.