### PR TITLE
Fix powder self immunity

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3168,7 +3168,7 @@ u8 AtkCanceller_UnableToUseMove(void)
             gBattleStruct->atkCancellerTracker++;
             break;
         case CANCELLER_POWDER_MOVE:
-            if (gBattleMoves[gCurrentMove].flags & FLAG_POWDER)
+            if ((gBattleMoves[gCurrentMove].flags & FLAG_POWDER) && (gBattlerAttacker != gBattlerTarget)) // Rage Powder targets the user
             {
                 if ((B_POWDER_GRASS >= GEN_6 && IS_BATTLER_OF_TYPE(gBattlerTarget, TYPE_GRASS))
                     || GetBattlerAbility(gBattlerTarget) == ABILITY_OVERCOAT)


### PR DESCRIPTION
Stops powder-immune mons being immune to self-targeting moves (e.g. Rage Powder).