### PR TITLE
Fix Thousand Arrows vs flying types

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -262,7 +262,7 @@
 #define FLAG_DMG_IN_AIR             (1 << 22) // X2 dmg on air, always hits target on air
 #define FLAG_HIT_IN_AIR             (1 << 23) // dmg is normal, always hits target on air
 #define FLAG_KEEN_EDGE_BOOST        (1 << 24)
-#define FLAG_HIT_AIRBORNE           (1 << 25) // For Thousand Arrows
+#define FLAG_DAMAGE_AIRBORNE           (1 << 25) // For Thousand Arrows
 
 // Split defines.
 #define SPLIT_PHYSICAL  0x0

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -7879,9 +7879,7 @@ static void MulByTypeEffectiveness(u16 *modifier, u16 move, u8 moveType, u8 batt
         mod = UQ_4_12(2.0);
     if (moveType == TYPE_GROUND && defType == TYPE_FLYING && IsBattlerGrounded(battlerDef) && mod == UQ_4_12(0.0))
         mod = UQ_4_12(1.0);
-    if (gBattleMoves[move].flags & FLAG_HIT_AIRBORNE && defType == TYPE_FLYING) // Thousand Arrows
-        mod = UQ_4_12(1.0);
-
+    
     if (gProtectStructs[battlerDef].kingsShielded && gBattleMoves[move].effect != EFFECT_FEINT)
         mod = UQ_4_12(1.0);
 
@@ -7920,7 +7918,14 @@ static u16 CalcTypeEffectivenessMultiplierInternal(u16 move, u8 moveType, u8 bat
         && gBattleMons[battlerDef].type3 != gBattleMons[battlerDef].type1)
         MulByTypeEffectiveness(&modifier, move, moveType, battlerDef, gBattleMons[battlerDef].type3, battlerAtk, recordAbilities);
 
-    if (moveType == TYPE_GROUND && !IsBattlerGrounded(battlerDef) && !(gBattleMoves[move].flags & FLAG_HIT_AIRBORNE))
+    // Thousand Arrows ignores type modifiers for flying mons
+    if (!IsBattlerGrounded(battlerDef) && (gBattleMoves[move].flags & FLAG_DAMAGE_AIRBORNE)
+        && (gBattleMons[battlerDef].type1 == TYPE_FLYING || gBattleMons[battlerDef].type2 == TYPE_FLYING || gBattleMons[battlerDef].type3 == TYPE_FLYING))
+    {
+        modifier = UQ_4_12(1.0);
+    }
+
+    if (moveType == TYPE_GROUND && !IsBattlerGrounded(battlerDef) && !(gBattleMoves[move].flags & FLAG_DAMAGE_AIRBORNE))
     {
         modifier = UQ_4_12(0.0);
         if (recordAbilities && GetBattlerAbility(battlerDef) == ABILITY_LEVITATE)

--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -2438,7 +2438,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_SELECTED,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_HIT_AIRBORNE,
+        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_DAMAGE_AIRBORNE,
         .split = SPLIT_PHYSICAL,
     },
 
@@ -9467,7 +9467,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 100,
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_HIT_IN_AIR | FLAG_HIT_AIRBORNE,
+        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGS_ROCK_AFFECTED | FLAG_HIT_IN_AIR | FLAG_DAMAGE_AIRBORNE,
         .split = SPLIT_PHYSICAL,
     },
 


### PR DESCRIPTION
Now does 1x damage to fliers always, ignoring their other types.