### PR TITLE
Fix capitalization for SafariZone Northeast NPC

### DIFF
--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -285,7 +285,7 @@ SafariZone_Northeast_Text_Boy: @ 82A59A4
 	.string "decide what I should catch.$"
 
 SafariZone_Northeast_Text_Woman: @ 82A5A09
-	.string "I heard that you can see PIKACHU here.\n"
+	.string "I heard that you can see Pikachu here.\n"
 	.string "Where might one be?$"
 
 SafariZone_Northeast_Text_Girl: @ 82A5A44


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for Issue #331

In 'data/scripts/safari_zone.inc', fixed capitalization from 'PIKACHU' to 'Pikachu':
```diff
- .string "I heard that you can see PIKACHU here.\n"
+ .string "I heard that you can see Pikachu here.\n"
```
<!--- Describe your changes in detail -->

## **Discord contact info**
### 🐄 daftcow#6571 
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->