### PR TITLE
Correct 'Mystical Fire' move description

### DIFF
--- a/src/data/text/move_descriptions.h
+++ b/src/data/text/move_descriptions.h
@@ -2349,7 +2349,7 @@ static const u8 sWATER_SHURIKENDescription[] = _(
 
 static const u8 sMYSTICAL_FIREDescription[] = _(
     "Breathes a special, hot\n"
-    "fire. May lower Sp. Atk.");
+    "fire. Lowers Sp. Atk.");
 
 static const u8 sSPIKY_SHIELDDescription[] = _(
     "Evades attack, and damages\n"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fixes Issue #327 

Mystical Fire always lowers the foe's Sp. Atk when the attack lands. The description now follows the format of similar moves such as Spirit Break's description:

> "Attacks with spirit-breaking
> force. Lowers Sp. Atk."



The move's description has been changed to reflect this in 'src/data/text/move_descriptions.h':

```diff
- "fire. May lower Sp. Atk.");
+ "fire. Lowers Sp. Atk.");
```
<!--- Describe your changes in detail -->

## **Discord contact info**
### 🐄 daftcow#6571
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->